### PR TITLE
Fix comment count in parsing Facebook response

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -378,7 +378,7 @@ class EA_Share_Count_Core{
 						if( isset( $body->comments ) )
 							$share_count['Facebook']['comment_count'] = intval( $body->comments );
 						elseif( isset( $body->share->comment_count ) )
-							$share_count['Facebook']['comment_count'] = intval( $body->comments );
+							$share_count['Facebook']['comment_count'] = intval( $body->share->comment_count );
 							
 						$share_count['Facebook']['like_count'] = $share_count['Facebook']['share_count'];
 						$share_count['Facebook']['total_count'] = $share_count['Facebook']['share_count'] + $share_count['Facebook']['comment_count'];


### PR DESCRIPTION
was getting:

```
[24-Aug-2016 05:13:23 UTC] PHP Notice:  Undefined property: stdClass::$comments in /var/www/web/app/plugins/EA-Share-Count/includes/class-core.php on line 381
[24-Aug-2016 05:13:23 UTC] PHP Stack trace:
[24-Aug-2016 05:13:23 UTC] PHP   1. shutdown_action_hook() /var/www/web/wp/wp-includes/load.php:0
[24-Aug-2016 05:13:23 UTC] PHP   2. do_action() /var/www/web/wp/wp-includes/load.php:671
[24-Aug-2016 05:13:23 UTC] PHP   3. EA_Share_Count_Core->update_share_counts() /var/www/web/wp/wp-includes/plugin.php:524
[24-Aug-2016 05:13:23 UTC] PHP   4. EA_Share_Count_Core->query_api() /var/www/web/app/plugins/EA-Share-Count/includes/class-core.php:473
```